### PR TITLE
Fixed up POST in FooCDN

### DIFF
--- a/Radabite/Backend/Interfaces/IFooCDNAccessor.cs
+++ b/Radabite/Backend/Interfaces/IFooCDNAccessor.cs
@@ -13,7 +13,7 @@ namespace Radabite.Backend.Interfaces
 
 		FooResponse GetInfo(string blobID);
 
-		FooResponse Post(string blobID, string filename);
+		FooResponse Post(string blobID, byte[] data);
 
 		FooResponse Put(string blobID, FooCDNAccessor.StorageType type);
 

--- a/Radabite/Backend/Interfaces/IFooCDNManager.cs
+++ b/Radabite/Backend/Interfaces/IFooCDNManager.cs
@@ -13,7 +13,7 @@ namespace Radabite.Backend.Interfaces
 
 		FooResponse GetInfo(string blobID);
 
-		FooResponse Post(string blobID, string filename);
+		FooResponse Post(string blobID, byte[] data);
 
 		FooResponse Put(string blobID, FooCDNAccessor.StorageType type);
 

--- a/Radabite/Backend/Managers/FooCDNManager.cs
+++ b/Radabite/Backend/Managers/FooCDNManager.cs
@@ -24,9 +24,9 @@ namespace Radabite.Backend.Managers
 			return ServiceManager.Kernel.Get<IFooCDNAccessor>().GetInfo(blobID);
 		}
 
-		public FooResponse Post(string blobID, string filename)
+		public FooResponse Post(string blobID, byte[] data)
 		{
-			return ServiceManager.Kernel.Get<IFooCDNAccessor>().Post(blobID, filename);
+			return ServiceManager.Kernel.Get<IFooCDNAccessor>().Post(blobID, data);
 		}
 
 		public FooResponse Put(string blobID, FooCDNAccessor.StorageType type)


### PR DESCRIPTION
We no longer have to write to a temp file to POST to FooCDN.  I also added a test that combines the parts of FooCDN and asserts that the string you stored is the string you get back. :smiley: 
